### PR TITLE
Simplify Setup.hs

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -1,6 +1,2 @@
 import Distribution.Simple
-import System.Cmd(system)
-
-main = defaultMainWithHooks $ simpleUserHooks { runTests = runElfTests }
-
-runElfTests a b pd lb = system "runhaskell -i./src ./tests/Test.hs" >> return ()
+main = defaultMain

--- a/elf.cabal
+++ b/elf.cabal
@@ -7,9 +7,9 @@ Author:        Erik Charlebois
 Copyright:     Erik Charlebois
 Maintainer:    Baojun Wang <wangbj@gmail.com>
 Stability:     stable
-Cabal-Version: >= 1.6
+Cabal-Version: >= 1.8
 Homepage:      https://github.com/wangbj/elf
-Build-Type:    Custom
+Build-Type:    Simple
 Synopsis:      Parser for ELF object format.
 Description:   Parser for ELF object format.
 Data-Files:    tests/empty.elf tests/Test.hs
@@ -22,3 +22,13 @@ library
     build-depends:   base >= 2 && < 5, bytestring, binary
     hs-source-dirs:  src
     exposed-modules: Data.Elf
+
+test-suite tests
+  type:           exitcode-stdio-1.0
+  hs-source-dirs: tests
+  main-is:        Test.hs
+  build-depends:
+    elf,
+    HUnit,
+    base,
+    bytestring


### PR DESCRIPTION
Cabal can run tests by itself and it's generally
better supported than a custom Setup.hs
I've had problems compiling this package because of
the custom Setup.hs, so I've made this patch.

I've tested it with:
```
cabal sandbox init
cabal install --dependencies-only --enable-tests
cabal build
cabal test
```

and the tests pass.